### PR TITLE
Add missing dependency tailwindcss

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Check out the [post](https://testdriven.io/blog/django-htmx-tailwind/).
 1. Install the Node dependencies:
 
     ```sh
-    $ npm install
-    $ npm install tailwindcss
+    $ npm install tailwindcss postcss postcss-cli autoprefixer @fullhuman/postcss-purgecss
     # you may need to install PostCSS globally as well
     # npm install --global postcss postcss-cli
     ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check out the [post](https://testdriven.io/blog/django-htmx-tailwind/).
 
     ```sh
     $ npm install
+    $ npm install tailwindcss
     # you may need to install PostCSS globally as well
     # npm install --global postcss postcss-cli
     ```


### PR DESCRIPTION
Tailwindcss is required for this project to run, but it's not included in package*.json